### PR TITLE
feat: add release workflow to build and publish a container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Publish Container to Packages
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: docker-oss.nexus.famedly.de
+  REGISTRY_USERNAME: famedly-ci
+  REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+  IMAGE_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest-16core
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Ensure IMAGE_NAME is lowercase
+        run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> $GITHUB_ENV
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds a `release.yml` that contains a workflow that runs when a release is published. It creates and publishes an image for the tag on the GHCR.