### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Ensure IMAGE_NAME is lowercase
         run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - name: Log in to the Container registry
         uses: docker/login-action@2ff7bc63ffa51414f77e9cbeea0d3297c1672d2e
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@2ff7bc63ffa51414f77e9cbeea0d3297c1672d2e
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USERNAME }}
           password: ${{ env.REGISTRY_PASSWORD }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@9e8d01178c767b734d2fef9a000ac2a2137f483f
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
- Update GitHub Actions in workflows to the latest upstream default-branch commit SHAs.
- Keep existing action paths and only replace refs after `@`.

## Verification
- Checked generated diff to include only `.github/**/*.yml` / `.github/**/*.yaml` workflow action refs.
- CI on this PR should validate the updated action versions.